### PR TITLE
AL-8091: Warn when base locale ARB is missing for script/country variants 

### DIFF
--- a/bin/generator/generator.dart
+++ b/bin/generator/generator.dart
@@ -17,7 +17,7 @@ class ApplangaGenerator {
 
   void generate() {
     try {
-      _warnIfBaseLocalesMissing();
+      if (_warnIfBaseLocalesMissing()) return;
       _generateLocalizationClass();
     } catch (e) {
       if (e is ApplangaConfigException) {
@@ -37,15 +37,18 @@ class ApplangaGenerator {
   /// ApplangaLocalizations. Warn the user so they can add the base language on
   /// the Applanga dashboard.
   /// See: https://api.flutter.dev/flutter/material/MaterialApp/supportedLocales.html
-  void _warnIfBaseLocalesMissing() {
+  /// Returns `true` if any warnings were issued (base locales are missing),
+  /// in which case [_generateLocalizationClass] should not be called because
+  /// the generated class would be incomplete.
+  bool _warnIfBaseLocalesMissing() {
     final template = config.arbTemplateFileName;
     final baseLanguage = config.baseLanguage;
     final baseSuffix = "_$baseLanguage.arb";
-    if (!template.endsWith(baseSuffix)) return;
+    if (!template.endsWith(baseSuffix)) return false;
     final prefix = template.substring(0, template.length - baseSuffix.length);
 
     final arbDir = Directory(path.dirname(config.arbTemplateFilePath));
-    if (!arbDir.existsSync()) return;
+    if (!arbDir.existsSync()) return false;
 
     final arbPrefix = "${prefix}_";
     final locales = <String>{};
@@ -75,6 +78,8 @@ class ApplangaGenerator {
           "`dart run applanga_flutter:pull` and `dart run applanga_flutter:generate`.\n"
           "See: https://api.flutter.dev/flutter/material/MaterialApp/supportedLocales.html");
     }
+
+    return missingBases.isNotEmpty;
   }
 
   void _generateLocalizationClass() {

--- a/bin/generator/generator.dart
+++ b/bin/generator/generator.dart
@@ -5,6 +5,7 @@ import 'package:analyzer/dart/ast/ast.dart';
 import 'package:analyzer/dart/ast/visitor.dart';
 import 'package:applanga_flutter/src/applanga_exception.dart';
 import 'package:dart_style/dart_style.dart' show DartFormatter;
+import 'package:path/path.dart' as path;
 import 'package:pub_semver/pub_semver.dart';
 
 import '../utils.dart';
@@ -16,6 +17,7 @@ class ApplangaGenerator {
 
   void generate() {
     try {
+      _warnIfBaseLocalesMissing();
       _generateLocalizationClass();
     } catch (e) {
       if (e is ApplangaConfigException) {
@@ -25,6 +27,53 @@ class ApplangaGenerator {
         Utils.errorWriteLn(
             "Something went wrong! Run `flutter gen-l10n` and try again, otherwise please get in touch with applanga support.");
       }
+    }
+  }
+
+  /// Flutter's gen-l10n requires a base locale ARB (language-only) whenever a
+  /// variant with a script or country code is present. If the base is missing,
+  /// gen-l10n can silently produce an incomplete [AppLocalizations] (e.g. with
+  /// wrong `supportedLocales`), which then propagates into the generated
+  /// ApplangaLocalizations. Warn the user so they can add the base language on
+  /// the Applanga dashboard.
+  /// See: https://api.flutter.dev/flutter/material/MaterialApp/supportedLocales.html
+  void _warnIfBaseLocalesMissing() {
+    final template = config.arbTemplateFileName;
+    final baseLanguage = config.baseLanguage;
+    final baseSuffix = "_$baseLanguage.arb";
+    if (!template.endsWith(baseSuffix)) return;
+    final prefix = template.substring(0, template.length - baseSuffix.length);
+
+    final arbDir = Directory(path.dirname(config.arbTemplateFilePath));
+    if (!arbDir.existsSync()) return;
+
+    final arbPrefix = "${prefix}_";
+    final locales = <String>{};
+    for (final entity in arbDir.listSync()) {
+      if (entity is! File) continue;
+      final name = path.basename(entity.path);
+      if (!name.startsWith(arbPrefix) || !name.endsWith(".arb")) continue;
+      locales.add(name.substring(arbPrefix.length, name.length - ".arb".length));
+    }
+
+    final missingBases = <String, List<String>>{};
+    for (final locale in locales) {
+      if (!locale.contains("_")) continue;
+      final base = locale.split("_").first;
+      if (locales.contains(base)) continue;
+      missingBases.putIfAbsent(base, () => []).add(locale);
+    }
+
+    for (final entry in missingBases.entries) {
+      final variants = (entry.value..sort()).join(", ");
+      Utils.warningWriteLn(
+          "Base locale '${entry.key}' is missing but variants exist: $variants.\n"
+          "Flutter requires a base locale ARB when script or country variants are used.\n"
+          "Without it, the generated AppLocalizations may be incomplete (e.g. supportedLocales),\n"
+          "and the resulting ${config.className} will silently miss values.\n"
+          "To fix: add '${entry.key}' as a language on the Applanga dashboard, then re-run\n"
+          "`dart run applanga_flutter:pull` and `dart run applanga_flutter:generate`.\n"
+          "See: https://api.flutter.dev/flutter/material/MaterialApp/supportedLocales.html");
     }
   }
 

--- a/bin/utils.dart
+++ b/bin/utils.dart
@@ -7,6 +7,7 @@ class Utils {
   static final _bluePen = AnsiPen()..blue(bold: true);
   static final _greenPen = AnsiPen()..green(bold: true);
   static final _redPen = AnsiPen()..red(bold: true);
+  static final _yellowPen = AnsiPen()..yellow(bold: true);
   static final _whitePen = AnsiPen()..white(bold: false);
 
   static void writeLn(String msg) {
@@ -19,6 +20,10 @@ class Utils {
 
   static void errorWriteLn(String msg) {
     stderr.writeln(_redPen("\n-> $msg"));
+  }
+
+  static void warningWriteLn(String msg) {
+    stderr.writeln(_yellowPen("\n-> $msg"));
   }
 
   static void successWriteLn(String msg) {

--- a/example/android/app/build.gradle
+++ b/example/android/app/build.gradle
@@ -30,7 +30,7 @@ if (flutterVersionName == null) {
 android {
     namespace 'com.applanga.example'
     compileSdkVersion flutter.compileSdkVersion
-    ndkVersion flutter.ndkVersion
+    ndkVersion "27.0.12077973"
 
     compileOptions {
         sourceCompatibility JavaVersion.VERSION_11

--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -2,7 +2,7 @@ import 'package:applanga_flutter/applanga_flutter.dart';
 import 'package:example/generated/applanga_localizations.dart';
 import 'package:example/second_page.dart';
 import 'package:flutter/material.dart';
-import 'package:example/l10n/app_localizations.dart';
+import 'package:example/generated/app_localizations.dart';
 
 void main() async {
   WidgetsFlutterBinding.ensureInitialized();

--- a/example/lib/second_page.dart
+++ b/example/lib/second_page.dart
@@ -1,6 +1,6 @@
 import 'package:applanga_flutter/applanga_flutter.dart';
 import 'package:flutter/material.dart';
-import 'package:example/l10n/app_localizations.dart';
+import 'package:example/generated/app_localizations.dart';
 
 class SecondPage extends StatelessWidget {
   const SecondPage({Key? key}) : super(key: key);


### PR DESCRIPTION
The applanga_flutter:generate command now scans the ARB directory and prints a yellow warning for each missing base locale, instructing the user to add the language on the Applanga dashboard.